### PR TITLE
WebGL

### DIFF
--- a/Editor/Extreal.Integration.AssetWorkflow.Addressables.Editor.asmdef
+++ b/Editor/Extreal.Integration.AssetWorkflow.Addressables.Editor.asmdef
@@ -5,6 +5,7 @@
         "Extreal.Core.Logging",
         "Extreal.Core.Common",
         "Extreal.Integration.AssetWorkflow.Addressables",
+        "Extreal.Integration.AssetWorkflow.Addressables.Custom.ResourceProviders",
         "Unity.Addressables",
         "Unity.Addressables.Editor",
         "Unity.ResourceManager",

--- a/Runtime/Custom/ResourceProviders/Extreal.Integration.AssetWorkflow.Addressables.Custom.ResourceProviders.asmdef
+++ b/Runtime/Custom/ResourceProviders/Extreal.Integration.AssetWorkflow.Addressables.Custom.ResourceProviders.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "Extreal.Integration.AssetWorkflow.Addressables.Custom.ResourceProviders",
+    "rootNamespace": "",
+    "references": [
+        "Unity.ResourceManager",
+        "Extreal.Core.Logging"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [
+        "WebGL"
+    ],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Runtime/Custom/ResourceProviders/Extreal.Integration.AssetWorkflow.Addressables.Custom.ResourceProviders.asmdef.meta
+++ b/Runtime/Custom/ResourceProviders/Extreal.Integration.AssetWorkflow.Addressables.Custom.ResourceProviders.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a963d8450eeba34f9ab69b417f037ac
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "jp.co.tis.extreal.integration.assetworkflow.addressables",
-  "version": "1.1.0-next.5",
+  "version": "1.2.0-next.2",
   "displayName": "Extreal.Integration.AssetWorkflow.Addressables",
   "unity": "2022.3",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "jp.co.tis.extreal.integration.assetworkflow.addressables",
-  "version": "1.1.0-next.4",
+  "version": "1.1.0-next.5",
   "displayName": "Extreal.Integration.AssetWorkflow.Addressables",
   "unity": "2022.3",
   "author": {


### PR DESCRIPTION
# 何の変更を加えましたか？

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました
  - サンプルが特にない

## 変更影響

- [x] GuideのReleaseページに変更内容が追加されることを確認しました
  - 特に関連変更がない
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
   - 以下guideのPRに「WebGLではこの機能を使用できない」旨を追記済み
     - https://github.com/extreal-dev/Extreal.Guide/pull/50/files#diff-b41319516d10e841a1d69149ee719c571dbab5efdf39349f4a6a11bf30c7612fR268
   - 利用者のプリ側で暗号化を使う場合に「Extreal.Integration.AssetWorkflow.Addressables.Custom.ResourceProviders」の命名空間をassemblyに追加する必要があるため、guideのPRで暗号化の部分に「命名空間を追加する」手順の記述を以下で追加した。
     - https://github.com/extreal-dev/Extreal.Guide/pull/50/commits/5ffeda63a538892f7af6eb8839f94f3525ca4ef8
- [x] GuideのLearningページに変更が反映されることを確認しました
  - 特に関連変更がない
- [x] Sample Applicationに変更が反映されることを確認しました
  - 特に関連変更がない

# レビュアーへのメッセージ
